### PR TITLE
Fix pattern matching bugs, fixing Will's new tests

### DIFF
--- a/staged-interp.scm
+++ b/staged-interp.scm
@@ -651,6 +651,10 @@
 
 (define (match-clauses mval clauses env val)
   (conde
+    ; a match fails if no clause matches; in
+    ; unstaged this happens when reaching
+    ; match-clauses with an empty list of clauses.
+    ; in staged, defer to runtime.
     ((== clauses '())
      (lift 'fail))
     ((fresh (p result-expr d penv c-yes c-no)
@@ -681,6 +685,11 @@
 
 (define (var-p-no-match var mval penv penv-out)
   (conde
+    ; a variable pattern cannot fail when it is
+    ; the first occurence of the name. unstaged
+    ; fails by failure of the lookupo below; in
+    ; staged we need to defer this failure to
+    ; runtime.
     ((symbolo var)
      (not-in-envo var penv)
      (lift 'fail))
@@ -688,13 +697,6 @@
        (symbolo var)
        (l=/= mval val)
        (== penv penv-out)
-       ;; This lookup is for linear pattern matching
-       ;; which is not supported by staging,
-       ;; since penv is not reified.
-       ;(lambda (st)
-       ;(display (walk* penv (state-S st)))
-       ;(display "\n")
-       ;st)
        (lookupo #t var penv val)))))
 
 (define (p-match p mval penv penv-out)

--- a/staged-interp.scm
+++ b/staged-interp.scm
@@ -680,15 +680,22 @@
        (not-in-envo var penv)))))
 
 (define (var-p-no-match var mval penv penv-out)
-  (fresh (val)
-    (symbolo var)
-    (l=/= mval val)
-    (== penv penv-out)
-    ;; This lookup is for linear pattern matching
-    ;; which is not supported by staging,
-    ;; since penv is not reified.
-    ;;(lookupo #t var penv val)
-    ))
+  (conde
+    ((symbolo var)
+     (not-in-envo var penv)
+     (lift 'fail))
+    ((fresh (val)
+       (symbolo var)
+       (l=/= mval val)
+       (== penv penv-out)
+       ;; This lookup is for linear pattern matching
+       ;; which is not supported by staging,
+       ;; since penv is not reified.
+       ;(lambda (st)
+       ;(display (walk* penv (state-S st)))
+       ;(display "\n")
+       ;st)
+       (lookupo #t var penv val)))))
 
 (define (p-match p mval penv penv-out)
   (conde
@@ -731,11 +738,18 @@
                (var-p-no-match var mval penv penv-out))
              z2)
             (lift `(conde ,z1 ,z2))))
-         ((== 'number? pred) ;; TODO: same pattern as symbol? above
-          (conde
-            ((lift `(not-numbero ,(expand mval))))
-            ((lift `(numbero ,(expand mval)))
-             (var-p-no-match var mval penv penv-out)))))))
+         ((== 'number? pred)
+          (fresh (z1 z2)
+            (lift-scope
+             (fresh ()
+               (lift `(not-numbero ,(expand mval))))
+             z1)
+            (lift-scope
+             (fresh ()
+               (lift `(numbero ,(expand mval)))
+               (var-p-no-match var mval penv penv-out))
+             z2)
+            (lift `(conde ,z1 ,z2)))))))
     ((fresh (quasi-p)
       (== (list 'quasiquote quasi-p) p)
       (quasi-p-no-match quasi-p mval penv penv-out)))))
@@ -765,21 +779,29 @@
          (== (list 'unquote p) quasi-p)
          (not-tago mval)
          (p-no-match p mval penv penv-out)))
-      ((fresh (a d v1 v2 penv^)
+      ((fresh (a d)
          (== `(,a . ,d) quasi-p)
          (=/= 'unquote a)
          (fresh (z1 z2)
            (lift-scope
-            (fresh ()
-              (== penv penv-out)
-              (lift `(literalo ,(expand mval))))
-            z1)
+             (fresh ()
+               (== penv penv-out)
+               (lift `(literalo ,(expand mval))))
+             z1)
            (lift-scope
-            (fresh ()
-              (l== `(,v1 . ,v2) mval)
-              (conde
-                ((quasi-p-no-match a v1 penv penv^))
-                ((quasi-p-match a v1 penv penv^)
-                 (quasi-p-no-match d v2 penv^ penv-out))))
-            z2)
-           (lift `(conde ,z1 ,z2))))))))
+             (fresh (penv^ v1 v2)
+               (l== `(,v1 . ,v2) mval)
+               (fresh (z3 z4)
+                 (lift-scope
+                   (fresh ()
+                     (quasi-p-no-match a v1 penv penv-out))
+                   z3)
+                 (lift-scope
+                   (fresh ()
+                     (quasi-p-match a v1 penv penv^)
+                     (quasi-p-no-match d v2 penv^ penv-out))
+                   z4)
+                 (lift `(conde ,z3 ,z4))))
+             z2)
+           (lift `(conde ,z1 ,z2)))
+         )))))

--- a/tests-dl.scm
+++ b/tests-dl.scm
@@ -94,15 +94,6 @@
      nnf-concept))
   '((Not Top)))
 
-(record-bench 'run-staged 'nnf-0)
-(time-test
-  (run #f (nnf-concept)
-    (evalo-staged
-     (nnf '(Not (AtLeast z hasChild)))
-     nnf-concept))
-  '((Not Top)))
-
-
 
 (record-bench 'run-unstaged 'nnf-0)
 (time-test

--- a/unstaged-interp.scm
+++ b/unstaged-interp.scm
@@ -390,6 +390,6 @@
        (=/= 'unquote a)
        (== `(,v1 . ,v2) mval)
        (conde
-         ((u-quasi-p-no-match a v1 penv penv^))
+         ((u-quasi-p-no-match a v1 penv penv-out))
          ((u-quasi-p-match a v1 penv penv^)
           (u-quasi-p-no-match d v2 penv^ penv-out)))))))


### PR DESCRIPTION
This seems to change one of the answers from a `tests-micro.scm` test. Could someone who understands those tests investigate to see whether it's a real breakage? Here's the failure:

```
Exception in test: Failed: (run-staged 10 (q) (evalo-staged (valid-ge? q) #t))

Expected:
((=== '_.0 '_.1)
 (=== '_.0 (cons '_.1 '_.2))
 (=== (cons '_.0 '_.1) '_.2)
 (call/fresh (lambda (_.0) (=== '_.1 '_.2)))
 (conj (=== '_.0 '_.1) (=== '_.2 '_.3))
 (=== (cons '_.0 '_.1) (cons '_.2 '_.3))
 (=== '_.0 (cons '_.1 (cons '_.2 '_.3)))
 (=== '_.0 (cons (cons '_.1 '_.2) '_.3))
 (disj (=== '_.0 '_.1) (=== '_.2 '_.3))
 (=== (cons '_.0 (cons '_.1 '_.2)) '_.3))

Computed:
((=== '_.0 '_.1)
 (=== '_.0 (cons '_.1 '_.2))
 (=== (cons '_.0 '_.1) '_.2)
 (conj (=== '_.0 '_.1) (=== '_.2 '_.3))
 (=== (cons '_.0 '_.1) (cons '_.2 '_.3))
 (=== '_.0 (cons '_.1 (cons '_.2 '_.3)))
 (=== '_.0 (cons (cons '_.1 '_.2) '_.3))
 (disj (=== '_.0 '_.1) (=== '_.2 '_.3))
 (=== (cons '_.0 (cons '_.1 '_.2)) '_.3)
 (=== '_.0 (cons (cons '_.1 '_.2) (cons '_.3 '_.4))))
```