### PR TITLE
avoid changes in canonical element in environment lookup

### DIFF
--- a/staged-interp.scm
+++ b/staged-interp.scm
@@ -390,7 +390,7 @@
     (conde
       ((== x y)
        (conde
-         ((fresh (v) (== `(val . ,v) b) ((if stage? l== ==) v t)))
+         ((fresh (v) (== `(val . ,v) b) ((if stage? l== ==) t v)))
          ((fresh (lam-expr code-expr)
             (== `(staged-rec ,lam-expr ,code-expr) b)
             ((if stage? l== ==) `(call ,x) t)))))


### PR DESCRIPTION
The main performance cost to the absento constraints in the appendo examples is from propagating the constraint from one var to the other when the canonical element changes. The canonical element changes because of the ordering of variables in the unification in environment lookup.

This change reorders those variables, avoiding the change in canonical element and the corresponding constraint propagation.

All the staged append tests we've been looking at run faster now, and the one using quoted literals now has a much smaller overhead as compared to environment extension.

(The numbers in the paper will need updating)