### PR TITLE
add xvfb dep, use w/racket, fix benchmk submod, call in bench script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM racket/racket:8.15-full
 
 # for benchmark collation
 RUN apt-get update
-RUN apt-get install -y python3
+RUN apt-get install -y python3 xvfb
 
 RUN raco pkg install --auto --no-docs syntax-spec-v2
 

--- a/benchrun.sh
+++ b/benchrun.sh
@@ -9,7 +9,7 @@ else
     BENCH_DIR="./bench-results"
 fi
 
-racket -y tests/bench-paper.rkt | tee bench-log-ex.txt
+xvfb-run racket -y tests/bench-paper.rkt | tee bench-log-ex.txt
 python3 benchread.py >$BENCH_DIR/bench_paper.tex
 cp bench-log-ex.txt bench-log-ex-paper.txt
 

--- a/tests/applications/proof.rkt
+++ b/tests/applications/proof.rkt
@@ -34,20 +34,20 @@
    (prover `(proof? ',prf))
    #t))
 
-(module+ benchmark
-  (record-bench 'eval-eval 'staging 'proofo #:description "Checks the validity of proofs for implicational propositional calculus"))
-
-(defrel (proofo prf valid-proof?)
-  (time-staged
-   (evalo-staged
-    (prover `(proof? ',prf))
-    valid-proof?)))
 
 (defrel (valid-proofo prf)
   (staged
    (evalo-staged
     (prover `(proof? ',prf))
     #t)))
+
+(module+ benchmark
+  (record-bench 'eval-eval 'staging 'proofo #:description "Checks the validity of proofs for implicational propositional calculus")
+  (defrel (proofo prf valid-proof?)
+	(time-staged
+	 (evalo-staged
+	  (prover `(proof? ',prf))
+	  valid-proof?)))
 
 (define (run-proofs)
   (define ex-proof1
@@ -127,8 +127,7 @@
 		 (proof-unstaged prf))))
 	'timeout))
 
-(module+ benchmark
-  (run-proofs))
+(run-proofs))
 
 (define (implication-chain size premise conclusion)
   (let loop ([previous premise] [acc '()] [size size])

--- a/tests/bench-paper.rkt
+++ b/tests/bench-paper.rkt
@@ -17,7 +17,7 @@
 
 ;; Staging the evalo relation running on (eval <program-text>) (thus faster eval functions in particular)
 (require "applications/or-lang-interp.rkt")
-(require "applications/proof.rkt")
+(require (submod "applications/proof.rkt" benchmark))
 (require "applications/peano-fib.rkt")
 (require "applications/parsing-with-derivatives.rkt")
 (require "applications/double-eval.rkt") ;; quines w/quasiquotes


### PR DESCRIPTION
 I'm still having trouble building the image locally, so this is somewhat aspirational. 

But this *should* 

- fix the issue with some racket package being angry about running headless
- make sure the benchmark script runs the entire proofo benchmark

That should consequently get the benchmark script to complete going through. Fingers crossed.